### PR TITLE
fix: vatid field rename to vat_id

### DIFF
--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -40,7 +40,7 @@ def get_custom_fields():
 		},
 		{
 			"label": "VAT ID",
-			"fieldname": "vatid",
+			"fieldname": "vat_id",
 			"fieldtype": "Data",
 			"read_only": 1,
 			"translatable": 0,
@@ -67,7 +67,7 @@ def get_custom_fields():
 		},
 		{
 			"label": "VAT ID",
-			"fieldname": "vatid",
+			"fieldname": "vat_id",
 			"fieldtype": "Data",
 			"read_only": 1,
 			"translatable": 0,


### PR DESCRIPTION
Renamed vatid field in Quotation, Sales Invoice & Sales Order to vat_id