### PR TITLE
Address and Transactions (Q, SO, SI) Enhancements

### DIFF
--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -20,6 +20,9 @@ def validate_tax_category_fields(doc, method=None):
     if not german_accounting_settings.service_item_group:
         frappe.throw('Please set Service Item Group in German Accounting Settings')
 
+    if not german_accounting_settings.good_or_service_selection:
+        frappe.throw('Please set Goods or Service Selection in German Accounting Settings')
+
     goods_item_group_list = get_parent_and_descendants_item_group_list(german_accounting_settings.goods_item_group)
     services_item_group_list = get_parent_and_descendants_item_group_list(german_accounting_settings.service_item_group)
     # Here we go through the item table and count the amounts for the two categories
@@ -31,6 +34,10 @@ def validate_tax_category_fields(doc, method=None):
 
     if goods_amt_sum > services_amt_sum:
         doc.item_group = german_accounting_settings.goods_item_group
+
+    elif goods_amt_sum == services_amt_sum:
+        good_or_service_selection = frappe.scrub(german_accounting_settings.good_or_service_selection)
+        doc.item_group = german_accounting_settings.get(good_or_service_selection)
 
     else:
         doc.item_group = german_accounting_settings.service_item_group

--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.utils import flt
 from frappe.utils.nestedset import get_descendants_of
 
+
 def validate_tax_category_fields(doc, method=None):
     goods_amt_sum = 0.0
     services_amt_sum = 0.0
@@ -11,16 +12,16 @@ def validate_tax_category_fields(doc, method=None):
         descendants_item_group = get_descendants_of("Item Group", item_group)
         return item_groups + descendants_item_group if descendants_item_group else item_groups
 
-    goods_item_group = frappe.get_cached_value('German Accounting Settings', None, 'goods_item_group')
-    service_item_group = frappe.get_cached_value('German Accounting Settings', None, 'service_item_group')
-    if not goods_item_group:
+    german_accounting_settings = frappe.get_cached_doc('German Accounting Settings')
+
+    if not german_accounting_settings.goods_item_group:
         frappe.throw('Please set Goods Item Group in German Accounting Settings')
 
-    if not service_item_group:
+    if not german_accounting_settings.service_item_group:
         frappe.throw('Please set Service Item Group in German Accounting Settings')
 
-    goods_item_group_list = get_parent_and_descendants_item_group_list(goods_item_group)
-    services_item_group_list = get_parent_and_descendants_item_group_list(service_item_group)
+    goods_item_group_list = get_parent_and_descendants_item_group_list(german_accounting_settings.goods_item_group)
+    services_item_group_list = get_parent_and_descendants_item_group_list(german_accounting_settings.service_item_group)
     # Here we go through the item table and count the amounts for the two categories
     for item in doc.get("items"):
         if item.item_group in goods_item_group_list:
@@ -28,8 +29,8 @@ def validate_tax_category_fields(doc, method=None):
         elif item.item_group in services_item_group_list:
             services_amt_sum += flt(item.amount)
 
-    # Test which amount is higher...
-    if goods_amt_sum >= services_amt_sum:
-        doc.item_group = goods_item_group
+    if goods_amt_sum > services_amt_sum:
+        doc.item_group = german_accounting_settings.goods_item_group
+
     else:
-        doc.item_group = service_item_group
+        doc.item_group = german_accounting_settings.service_item_group

--- a/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
+++ b/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
@@ -9,7 +9,10 @@
  "field_order": [
   "goods_item_group",
   "column_break_cx7ey",
-  "service_item_group"
+  "service_item_group",
+  "good_or_service_selection",
+  "section_break_who7o",
+  "mappings"
  ],
  "fields": [
   {
@@ -31,12 +34,30 @@
    "label": "Service Item Group",
    "options": "Item Group",
    "reqd": 1
+  },
+  {
+   "fieldname": "section_break_who7o",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "mappings",
+   "fieldtype": "Table",
+   "label": "Mappings",
+   "options": "Mappings"
+  },
+  {
+   "description": "In case the amount of Goods and Service Item Groups are equal this case will be chosen.",
+   "fieldname": "good_or_service_selection",
+   "fieldtype": "Select",
+   "label": "Goods or Service Selection",
+   "options": "\nGoods Item Group\nService Item Group",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-28 13:20:29.747979",
+ "modified": "2023-11-14 17:01:07.799255",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "German Accounting Settings",

--- a/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
+++ b/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
@@ -10,9 +10,7 @@
   "goods_item_group",
   "column_break_cx7ey",
   "service_item_group",
-  "good_or_service_selection",
-  "section_break_who7o",
-  "mappings"
+  "good_or_service_selection"
  ],
  "fields": [
   {
@@ -36,16 +34,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "section_break_who7o",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "mappings",
-   "fieldtype": "Table",
-   "label": "Mappings",
-   "options": "Mappings"
-  },
-  {
    "description": "In case the amount of Goods and Service Item Groups are equal this case will be chosen.",
    "fieldname": "good_or_service_selection",
    "fieldtype": "Select",
@@ -57,7 +45,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-14 17:01:07.799255",
+ "modified": "2023-11-14 20:15:55.912740",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "German Accounting Settings",

--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -28,6 +28,13 @@ app_license = "MIT"
 # include js in page
 # page_js = {"page" : "public/js/file.js"}
 
+# include js in doctype views
+doctype_js = {
+	"Address": "public/js/address.js",
+	"Quotation": "public/js/quotation.js",
+	"Sales Order": "public/js/sales_order.js",
+	"Sales Invoice": "public/js/sales_invoice.js"
+}
 
 doc_events = {
     "Quotation": {

--- a/german_accounting/public/js/address.js
+++ b/german_accounting/public/js/address.js
@@ -1,0 +1,6 @@
+frappe.ui.form.on("Address", {
+	onload: function (frm) {
+        frm.set_df_property('tax_category', 'reqd', 1);
+        frm.add_fetch('country', 'tax_category', 'tax_category');
+	},
+});

--- a/german_accounting/public/js/quotation.js
+++ b/german_accounting/public/js/quotation.js
@@ -1,0 +1,5 @@
+frappe.ui.form.on("Quotation", {
+	onload: function (frm) {
+        frm.set_df_property('tax_category', 'reqd', 1);
+	},
+});

--- a/german_accounting/public/js/sales_invoice.js
+++ b/german_accounting/public/js/sales_invoice.js
@@ -1,0 +1,5 @@
+frappe.ui.form.on("Sales Invoice", {
+	onload: function (frm) {
+        frm.set_df_property('tax_category', 'reqd', 1);
+	},
+});

--- a/german_accounting/public/js/sales_order.js
+++ b/german_accounting/public/js/sales_order.js
@@ -1,0 +1,5 @@
+frappe.ui.form.on("Sales Order", {
+	onload: function (frm) {
+        frm.set_df_property('tax_category', 'reqd', 1);
+	},
+});

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -25,8 +25,8 @@ def delete_custom_fields(custom_fields):
 def get_custom_fields():
 	custom_fields_quotation = [
 		{
-			"label": "IMAT Section",
-			"fieldname": "imat_section",
+			"label": "German Accounting",
+			"fieldname": "german_accounting",
 			"fieldtype": "Section Break",
 		},
 		{
@@ -35,7 +35,7 @@ def get_custom_fields():
 			"fieldtype": "Data",
 			"read_only": 1,
 			"translatable": 0,
-			"insert_after": "imat_section",
+			"insert_after": "german_accounting",
 			"description": "This field will be filled by either 'Goods' or 'Services' depending on the result that is calculated in the item table."
 		},
 		{
@@ -52,8 +52,8 @@ def get_custom_fields():
 
 	custom_fields_so_si = [
 		{
-			"label": "IMAT Section",
-			"fieldname": "imat_section",
+			"label": "German Accounting",
+			"fieldname": "german_accounting",
 			"fieldtype": "Section Break",
 		},
 		{
@@ -62,7 +62,7 @@ def get_custom_fields():
 			"fieldtype": "Data",
 			"read_only": 1,
 			"translatable": 0,
-			"insert_after": "imat_section",
+			"insert_after": "german_accounting",
 			"description": "This field will be filled by either 'Goods' or 'Services' depending on the result that is calculated in the item table."
 		},
 		{
@@ -79,8 +79,8 @@ def get_custom_fields():
 
 	custom_fields_country = [
 		{
-			"label": "IMAT",
-			"fieldname": "imat",
+			"label": "German Accounting",
+			"fieldname": "german_accounting",
 			"fieldtype": "Section Break",
 		},
 		{
@@ -88,8 +88,12 @@ def get_custom_fields():
 			"fieldname": "tax_category",
 			"fieldtype": "Link",
 			"options": "Tax Category",
-			"insert_after": "imat",
-		}
+			"insert_after": "german_accounting",
+		},
+		{
+			"fieldtype": "Section Break",
+			"fieldname": "other_fields_sb",
+		},
 	]
 
 	return {

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -77,8 +77,24 @@ def get_custom_fields():
 		}
 	]
 
+	custom_fields_country = [
+		{
+			"label": "IMAT",
+			"fieldname": "imat",
+			"fieldtype": "Section Break",
+		},
+		{
+			"label": "Tax Category",
+			"fieldname": "tax_category",
+			"fieldtype": "Link",
+			"options": "Tax Category",
+			"insert_after": "imat",
+		}
+	]
+
 	return {
 		"Quotation": custom_fields_quotation,
 		"Sales Order": custom_fields_so_si,
-		"Sales Invoice": custom_fields_so_si
+		"Sales Invoice": custom_fields_so_si,
+		"Country": custom_fields_country
 	}


### PR DESCRIPTION
Fixed issue #19
1. Field tax_category to Country Doctype
![image](https://github.com/phamos-eu/German-Accounting/assets/25414115/6b2393ec-9649-416b-8204-3152fdccd81e)

2. Field tax_category fetch_from and mandatory n Address docType 
![image](https://github.com/phamos-eu/German-Accounting/assets/25414115/63c1adfa-56ab-42ed-826e-fb2c93277eea)

3. Field tax_category madatory in Quotation, Sales Order, and Sales Invoice

4. Field in German Accounting Setting for case in Quotation, Sales Order, and Sales Invoice where Goods and Service Item amounts are equal
![image](https://github.com/phamos-eu/German-Accounting/assets/25414115/aeb09075-e991-499b-8c44-b76a9a7e1295)
