### PR TITLE
quotation fetch from field customer_type

### DIFF
--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -30,7 +30,6 @@ app_license = "MIT"
 
 # include js in doctype views
 doctype_js = {
-	"Address": "public/js/address.js",
     "Quotation": "public/js/quotation.js"
 }
 

--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -30,7 +30,8 @@ app_license = "MIT"
 
 # include js in doctype views
 doctype_js = {
-	"Address": "public/js/address.js"
+	"Address": "public/js/address.js",
+    "Quotation": "public/js/quotation.js"
 }
 
 doc_events = {

--- a/german_accounting/public/js/address.js
+++ b/german_accounting/public/js/address.js
@@ -1,6 +1,0 @@
-frappe.ui.form.on("Address", {
-	onload: function (frm) {
-        frm.set_df_property('tax_category', 'reqd', 1);
-        frm.add_fetch('country', 'tax_category', 'tax_category');
-	},
-});

--- a/german_accounting/public/js/quotation.js
+++ b/german_accounting/public/js/quotation.js
@@ -1,0 +1,30 @@
+frappe.ui.form.on("Quotation", {
+	validate: function (frm) {
+        frm.events.add_fetch_customer_type(frm)
+	},
+
+    quotation_to: function (frm) {
+        frm.events.add_fetch_customer_type(frm)
+    },
+
+    party_name: function (frm) {
+        frm.events.add_fetch_customer_type(frm)
+    },
+
+    add_fetch_customer_type: function (frm) {
+        if (frm.doc.quotation_to)  {
+            if (frm.doc.quotation_to === 'Customer' && frm.doc.party_name) {
+                frm.add_fetch('party_name', 'customer_type', 'customer_type');
+            } else if (frm.doc.quotation_to === 'Lead' && frm.doc.party_name) {
+                frappe.db.get_value('Lead', frm.doc.party_name, 'organization_lead', function(value) {
+                    debugger;
+                    if (value['organization_lead'] === 1) {
+                        frm.set_value('customer_type', 'Company')
+                    } else {
+                        frm.set_value('customer_type', 'Individual')
+                    }
+                });
+            }
+        }
+	},
+});

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -1,10 +1,10 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
-
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
 def after_migrate():
 	create_custom_fields(get_custom_fields())
-
+	create_property_setters()
 
 def before_uninstall():
 	delete_custom_fields(get_custom_fields())
@@ -123,3 +123,9 @@ def get_custom_fields():
 		"Sales Invoice": custom_fields_so_si,
 		"Country": custom_fields_country
 	}
+
+
+def create_property_setters():
+	# Address property setter
+	make_property_setter("Address", "tax_category", "fetch_from", "country.tax_category", "Small Text")
+	make_property_setter("Address", "tax_category", "reqd", 1, "Check")

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -51,11 +51,12 @@ def get_custom_fields():
 		{
 			"label": "Customer Type",
 			"fieldname": "customer_type",
-			"fieldtype": "Data",
+			"fieldtype": "Select",
+			"options": "\nCompany\nIndividual",
+			"default": "",
 			"read_only": 1,
 			"translatable": 0,
 			"insert_after": "vat_id",
-			"fetch_from": "party_name.customer_type",
 		}
 	]
 

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -88,7 +88,9 @@ def get_custom_fields():
 		{
 			"label": "Customer Type",
 			"fieldname": "customer_type",
-			"fieldtype": "Data",
+			"fieldtype": "Select",
+			"options": "\nCompany\nIndividual",
+			"default": "",
 			"read_only": 1,
 			"translatable": 0,
 			"insert_after": "vat_id",


### PR DESCRIPTION
1. In lead there's is no field customer_type instead we got field `'Lead is an Organization' (organization_lead)` in lead, so moving logic of fetch_from in custom field json to quotaion js file
2. customer_type field as select field just like in Customer Doctype field (customer_type)
3. Added property setters for address doctype via python