### PR TITLE
fix: updated German tax defaults name and properties in table

### DIFF
--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -58,8 +58,9 @@ def setting_tax_defaults(doc):
             'is_vat_applicable': is_vat_applicable
         }
 
-        if frappe.db.exists('Custom Item Tax', filters):
-            item_tax_template = frappe.get_cached_doc('Custom Item Tax', filters)
+        if frappe.db.exists('Germany Accounting Tax Defaults', filters):
+            item_tax_template = frappe.get_cached_doc('Germany Accounting Tax Defaults', filters)
+            frappe.msgprint(item_tax_template.item_tax_template)
             for item in doc.items:
                 if item_tax_template.item_tax_template:
                     item.item_tax_template = item_tax_template.item_tax_template
@@ -75,7 +76,7 @@ def setting_tax_defaults(doc):
             doc.run_method("calculate_taxes_and_totals")
             
         else:
-            frappe.msgprint('Please set Custom Item Tax in {0} for tax category <b>{1}</b>'.format(frappe.get_desk_link('Item Group', doc.item_group), doc.tax_category))
+            frappe.msgprint('Please set Germany Accounting Tax Defaults in {0} for tax category <b>{1}</b>'.format(frappe.get_desk_link('Item Group', doc.item_group), doc.tax_category))
 
 def set_customer_type(doc):
     if doc.doctype == 'Quotation':

--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -76,7 +76,7 @@ def setting_tax_defaults(doc):
             doc.run_method("calculate_taxes_and_totals")
             
         else:
-            frappe.msgprint('Please set Germany Accounting Tax Defaults in {0} for tax category <b>{1}</b>'.format(frappe.get_desk_link('Item Group', doc.item_group), doc.tax_category))
+            frappe.msgprint('Please set Germany Accounting Taxes in {0} for tax category <b>{1}</b>'.format(frappe.get_desk_link('Item Group', doc.item_group), doc.tax_category))
 
 def set_customer_type(doc):
     if doc.doctype == 'Quotation':

--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -58,8 +58,8 @@ def setting_tax_defaults(doc):
             'is_vat_applicable': is_vat_applicable
         }
 
-        if frappe.db.exists('Germany Accounting Tax Defaults', filters):
-            item_tax_template = frappe.get_cached_doc('Germany Accounting Tax Defaults', filters)
+        if frappe.db.exists('German Accounting Tax Defaults', filters):
+            item_tax_template = frappe.get_cached_doc('German Accounting Tax Defaults', filters)
             frappe.msgprint(item_tax_template.item_tax_template)
             for item in doc.items:
                 if item_tax_template.item_tax_template:
@@ -76,7 +76,7 @@ def setting_tax_defaults(doc):
             doc.run_method("calculate_taxes_and_totals")
             
         else:
-            frappe.msgprint('Please set Germany Accounting Taxes in {0} for tax category <b>{1}</b>'.format(frappe.get_desk_link('Item Group', doc.item_group), doc.tax_category))
+            frappe.msgprint('Please set German Accounting Tax Defaults in {0} for Tax Category <b>{1}</b>'.format(frappe.get_desk_link('Item Group', doc.item_group), doc.tax_category))
 
 def set_customer_type(doc):
     if doc.doctype == 'Quotation':

--- a/german_accounting/german_accounting/doctype/germany_accounting_tax_defaults/germany_accounting_tax_defaults.json
+++ b/german_accounting/german_accounting/doctype/germany_accounting_tax_defaults/germany_accounting_tax_defaults.json
@@ -5,13 +5,13 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "tax_category",
   "item_tax_template",
   "sales_taxes_and_charges_template",
-  "tax_category",
   "column_break_rfnx7",
   "income_account",
-  "is_vat_applicable",
-  "customer_type"
+  "customer_type",
+  "is_vat_applicable"
  ],
  "fields": [
   {
@@ -21,14 +21,16 @@
    "label": "Item Tax Template",
    "oldfieldname": "tax_type",
    "oldfieldtype": "Link",
-   "options": "Item Tax Template"
+   "options": "Item Tax Template",
+   "reqd": 1
   },
   {
    "fieldname": "sales_taxes_and_charges_template",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Sales Taxes and Charges Template",
-   "options": "Sales Taxes and Charges Template"
+   "options": "Sales Taxes and Charges Template",
+   "reqd": 1
   },
   {
    "fieldname": "tax_category",
@@ -37,7 +39,8 @@
    "label": "Tax Category",
    "oldfieldname": "tax_rate",
    "oldfieldtype": "Currency",
-   "options": "Tax Category"
+   "options": "Tax Category",
+   "reqd": 1
   },
   {
    "fieldname": "income_account",
@@ -60,16 +63,18 @@
   {
    "fieldname": "customer_type",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Customer Type",
-   "options": "\nindividual\nCompany"
+   "options": "\nindividual\nCompany",
+   "reqd": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-12-20 18:16:07.204665",
+ "modified": "2024-01-06 15:01:49.387730",
  "modified_by": "Administrator",
  "module": "German Accounting",
- "name": "Custom Item Tax",
+ "name": "Germany Accounting Tax Defaults",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",

--- a/german_accounting/german_accounting/doctype/germany_accounting_tax_defaults/germany_accounting_tax_defaults.py
+++ b/german_accounting/german_accounting/doctype/germany_accounting_tax_defaults/germany_accounting_tax_defaults.py
@@ -4,5 +4,5 @@
 # import frappe
 from frappe.model.document import Document
 
-class CustomItemTax(Document):
+class GermanyAccountingTaxDefaults(Document):
 	pass

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -116,10 +116,10 @@ def get_custom_fields():
 
 	custom_fields_item_group = [
 		{
-			"label": "Custom Taxes",
-			"fieldname": "custom_taxes",
+			"label": "Germany Accounting Taxes",
+			"fieldname": "german_accounting_taxes",
 			"fieldtype": "Table",
-			"options": "Custom Item Tax",
+			"options": "Germany Accounting Tax Defaults",
 			"insert_after": "taxes"
 		}	
 	]


### PR DESCRIPTION
1. In Item Group custom field (Child table) 'Custom Taxes' should be renamed to 'Germany Accounting Tax Defaults'.
2. 'Tax Category' should be set mandatory and re-positioned as 1st field in table
3. 'Item Tax Template', 'Sales Taxes and Charges Template' and 'Customer Type' should also be set mandatory .