### PR TITLE
fix: covered edge case and added more informative message

### DIFF
--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.utils import flt
 from frappe.utils.nestedset import get_descendants_of
 
@@ -74,9 +75,18 @@ def setting_tax_defaults(doc):
 
             doc.run_method("set_missing_values")
             doc.run_method("calculate_taxes_and_totals")
-            
         else:
-            frappe.msgprint('Please set German Accounting Tax Defaults in {0} for Tax Category <b>{1}</b>'.format(frappe.get_desk_link('Item Group', doc.item_group), doc.tax_category))
+            for item in doc.items:
+                if doc.doctype == "Sales Invoice":
+                    item.income_account = ""
+                
+                item.item_tax_template = ""
+
+            doc.taxes = []
+            doc.taxes_and_charges = ""
+            doc.run_method("set_missing_values")
+            doc.run_method("calculate_taxes_and_totals")
+            frappe.msgprint(_("This case is not reflected in the table (German Accounting Tax Defaults) in {0}. Please check the fields tax_category, customer_type, is_vat_applicable and add your combination to the table.").format(frappe.get_desk_link("Item Group ", doc.item_group)))
 
 def set_customer_type(doc):
     if doc.doctype == 'Quotation':

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -116,7 +116,7 @@ def get_custom_fields():
 
 	custom_fields_item_group = [
 		{
-			"label": "German Accounting Taxes",
+			"label": "German Accounting Tax Defaults",
 			"fieldname": "german_accounting_taxes",
 			"fieldtype": "Table",
 			"options": "German Accounting Tax Defaults",


### PR DESCRIPTION
1. Child table in Item group label change from 'German Accounting Taxes' to 'German Accounting Tax Defaults' to make it more consistent 
2. Update message in case tax defaults are not found ("This case is not reflected in the table (German Accounting Tax Defaults) in Item Group X. Please check the fields tax_category, customer_type, is_vat_applicable and add your combination to the table.")    
3. Reset auto set field in case tax defaults are not found.