### PR TITLE
changes in datev si report

### DIFF
--- a/german_accounting/german_accounting/report/datev_sales_invoice/datev_sales_invoice.py
+++ b/german_accounting/german_accounting/report/datev_sales_invoice/datev_sales_invoice.py
@@ -42,9 +42,9 @@ def get_columns(filters):
         },
         {
             "label": _("Income Account"),
-            "fieldtype": "Link",
+            "fieldtype": "Data",
             "fieldname": "income_account",
-            "options": "Account",
+            # "options": "Account",
             "width": 130
         },
         {
@@ -68,9 +68,9 @@ def get_columns(filters):
         },
         {
             "label": _("Debitor No"),
-            "fieldtype": "Link",
+            "fieldtype": "Data",
             "fieldname": "debit_to",
-            "options": "Account",
+            # "options": "Account",
             "width": 120
         },
         {
@@ -148,7 +148,7 @@ def get_data(filters):
             tax_percentage = line_item_details[0].tax_rate
 
         ### Debitor No DATEV 
-        deb_no_datev = d.debit_to.split("-")[0]
+        deb_no_datev = d.debit_to.split("-")[0].replace(" ", "")
         if len(deb_no_datev) < 9:
             n = 9 - len(deb_no_datev)
             zeros = '0' * n


### PR DESCRIPTION

1. Removed unwanted white space from "Debitor No DATEV" column
2. Now the "Debitor No DATEV" column showing 9 digits
3. Removed link from "Income Account" and "Debitor No" columns 

![Greenshot 2024-02-20 19 43 13](https://github.com/phamos-eu/German-Accounting/assets/39581257/caa715ca-07c2-4859-b477-8d1da15578d5)
