### PR TITLE
fix: added currency in pdf format

### DIFF
--- a/german_accounting/german_accounting/report/datev_sales_invoice_export/datev_sales_invoice_export.html
+++ b/german_accounting/german_accounting/report/datev_sales_invoice_export/datev_sales_invoice_export.html
@@ -57,6 +57,6 @@
 	</tbody>
 </table>
 
-<p>Net Total {%= sumPdfNetTotal %}</p>
-<p>Gross Total {%= sumPdfTotal %}</p>
+<p>Net Total {%= format_currency(sumPdfNetTotal) %}</p>
+<p>Gross Total {%= format_currency(sumPdfTotal) %}</p>
 <p class="text-right text-muted">Printed On {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>


### PR DESCRIPTION
Currency formatting in pdf format:
![image](https://github.com/phamos-eu/German-Accounting/assets/25414115/af4b64b6-b912-4886-91be-854d75b78f52)
