### PR TITLE
Issue # 18 | Set Billing Address data in masters

### DIFF
--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -29,6 +29,9 @@ app_license = "MIT"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
+doctype_js = {
+    "Customer" : "public/js/customer.js"
+}
 
 doc_events = {
     "Quotation": {

--- a/german_accounting/public/js/customer.js
+++ b/german_accounting/public/js/customer.js
@@ -1,0 +1,15 @@
+frappe.ui.form.on('Customer', {
+    onload(frm) {
+        // FILTER BILLING ADDRESS WITH RESPECTIVE CONDITIONS
+        frm.set_query('billing_address', function () {
+            return {
+                query: 'frappe.contacts.doctype.address.address.address_query',
+                filters: {
+                    is_primary_address: 1,
+                    link_doctype: frm.doc.doctype,
+                    link_name: frm.doc.name
+                }
+            };
+        });
+    }
+})

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -152,10 +152,28 @@ def get_custom_fields():
 		}	
 	]
 
+	custom_fields_customer = [
+		{
+			"label": "German Accounting",
+			"fieldname": "imat",
+			"fieldtype": "Section Break",
+			"insert_after": None,
+		},
+		{
+			"label": "Billing Address",
+			"fieldname": "billing_address",
+			"fieldtype": "Link",
+			"description": "This represents the standard billing address used for the export for DATEV debtors file.",
+			"insert_after": "imat",
+			"options": "Address"
+		}
+	]
+
 	return {
 		"Quotation": custom_fields_quotation,
 		"Sales Order": custom_fields_so,
 		"Item Group": custom_fields_item_group,
 		"Sales Invoice": custom_fields_si,
-		"Country": custom_fields_country
+		"Country": custom_fields_country,
+		"Customer": custom_fields_customer
 	}


### PR DESCRIPTION
### **_Issue \# 18 Set Billing Address data in masters_**

1. Add a section "German Accounting" 
<img width="1097" alt="Screenshot 2024-03-20 at 23 18 15" src="https://github.com/phamos-eu/German-Accounting/assets/14124603/5fc71578-da98-44a0-9525-29522f58c64d">

2. create a link field to address with the description "This represents the standard billing address used for the export for DATEV debtors file." as shown above. The link field should filter for a) linked customer and preferred Billing Address
<img width="1287" alt="Screenshot 2024-03-20 at 23 13 33" src="https://github.com/phamos-eu/German-Accounting/assets/14124603/3e4d2c8c-9918-4ea2-bc66-8dc2c6f34628">
<img width="989" alt="Screenshot 2024-03-20 at 23 14 30" src="https://github.com/phamos-eu/German-Accounting/assets/14124603/2b5847de-54de-4c3c-bf55-2f6d39368c84">
