### PR TITLE
Issue#11 hide message from Sales Invoice Tax Logic

### DIFF
--- a/german_accounting/events/extended_tax_category.py
+++ b/german_accounting/events/extended_tax_category.py
@@ -49,6 +49,7 @@ def validate_tax_category_fields(doc, method=None):
 
 
 def setting_tax_defaults(doc):
+    track_logs = frappe.db.get_single_value("German Accounting Settings", "track_logs")
     if doc.doctype == 'Quotation' and doc.quotation_to == 'Customer' and doc.party_name:
         doc.tax_id = frappe.get_cached_value("Customer", doc.party_name, "tax_id")
 
@@ -61,10 +62,10 @@ def setting_tax_defaults(doc):
             'customer_type': doc.customer_type,
             'is_vat_applicable': is_vat_applicable
         }
-
         if frappe.db.exists('German Accounting Tax Defaults', filters):
             item_tax_template = frappe.get_cached_doc('German Accounting Tax Defaults', filters)
-            frappe.msgprint(item_tax_template.item_tax_template)
+            if track_logs:
+                frappe.msgprint(item_tax_template.item_tax_template)
             for item in doc.items:
                 if item_tax_template.item_tax_template:
                     item.item_tax_template = item_tax_template.item_tax_template

--- a/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
+++ b/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "goods_item_group",
+  "track_logs",
   "column_break_cx7ey",
   "service_item_group",
   "good_or_service_selection",
@@ -52,12 +53,18 @@
    "fieldname": "include_header_in_csv",
    "fieldtype": "Check",
    "label": "Include Header in CSV"
+  },
+  {
+   "default": "0",
+   "fieldname": "track_logs",
+   "fieldtype": "Check",
+   "label": "Track Logs"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-11 15:57:38.687485",
+ "modified": "2024-03-26 09:10:35.994938",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "German Accounting Settings",
@@ -75,6 +82,5 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+ "sort_order": "DESC"
 }


### PR DESCRIPTION
Added Track Log Checkbox in German Accounting Settings for track the logs, Currently in this repo track is logging in sales invoice
https://git.phamos.eu/imat/imat-german-accounting/-/issues/11

Added a checkbox for tracking logs conditionaly 

Logs Can be seen in the message box in sales invoice
