### PR TITLE
Issue# 9 | Change tax category logic in address

### DIFF
--- a/german_accounting/events/address.py
+++ b/german_accounting/events/address.py
@@ -1,9 +1,0 @@
-import frappe
-from frappe.utils import flt
-
-
-def set_tax_category(doc, method=None):
-    if doc.country:
-        tax_category = frappe.get_cached_value('Country', doc.country, 'tax_category')
-        if tax_category:
-            doc.tax_category = tax_category

--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -18,6 +18,7 @@ fixtures = [
 				"in",
 				[
 					"Address-is_primary_address-description"
+					"Address-tax_category-fetch_if_empty"
 				],
 			)
 		},

--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -57,9 +57,6 @@ doc_events = {
     "Sales Invoice": {
         "validate": "german_accounting.events.extended_tax_category.validate_tax_category_fields"
 	},
-    "Address": {
-        "validate": "german_accounting.events.address.set_tax_category"
-    }
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}


### PR DESCRIPTION
- Change tax category from readonly from editable after save
- Remove override functionality on tax_category field which is fetch_from country

