### PR TITLE
Added Breadcrumbs and Attachment Restrictions

### DIFF
--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
@@ -120,7 +120,7 @@ frappe.ui.form.on('DATEV Action Panel', {
 
 	show_report: function(frm){
 		frappe.open_in_new_tab = true;
-		frappe.set_route('query-report', 'DATEV Sales Invoice', {})
+		frappe.set_route('query-report', 'DATEV Sales Invoice Export', {})
 	}
 
 });

--- a/german_accounting/german_accounting/doctype/datev_export_log/datev_export_log.js
+++ b/german_accounting/german_accounting/doctype/datev_export_log/datev_export_log.js
@@ -2,7 +2,7 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('DATEV Export Log', {
-	// refresh: function(frm) {
-
-	// }
+	refresh: function(frm) {
+		$('.attachment-row').find(".remove-btn").remove()
+	}
 });

--- a/german_accounting/german_accounting/doctype/datev_export_log/datev_export_log.json
+++ b/german_accounting/german_accounting/doctype/datev_export_log/datev_export_log.json
@@ -38,23 +38,26 @@
   {
    "fieldname": "sales_invoice_csv",
    "fieldtype": "Attach",
-   "label": "Sales Invoice CSV"
+   "label": "Sales Invoice CSV",
+   "read_only": 1
   },
   {
    "fieldname": "sales_invoice_pdf",
    "fieldtype": "Attach",
-   "label": "Sales Invoice PDF"
+   "label": "Sales Invoice PDF",
+   "read_only": 1
   },
   {
    "fieldname": "debtors_csv",
    "fieldtype": "Attach",
-   "label": "Debtors CSV"
+   "label": "Debtors CSV",
+   "read_only": 1
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-31 01:08:03.606581",
+ "modified": "2024-04-03 12:12:40.988326",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV Export Log",

--- a/german_accounting/german_accounting/report/datev_sales_invoice_export/datev_sales_invoice_export.js
+++ b/german_accounting/german_accounting/report/datev_sales_invoice_export/datev_sales_invoice_export.js
@@ -40,5 +40,8 @@ frappe.query_reports["DATEV Sales Invoice Export"] = {
             "options": "\nSales Invoice CSV\nSales Invoice PDF\nDebtors CSV",
             "reqd": 1
         }
-    ]
+    ],
+    onload: function(){
+        frappe.breadcrumbs.add("German Accounting")
+    }
 };


### PR DESCRIPTION
1. Added German Accounting Breadcrumbs in Datev Sales invoice export report
2. Updated report link in datev action panel 
3. Added Restriction in Export Logs for removing the attachment