### PR TITLE
feat: create "DATEV OPOS Import" doctype and add a custom import button

### DIFF
--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, phamos.eu and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('DATEV OPOS Import', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
@@ -2,7 +2,15 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('DATEV OPOS Import', {
-	// refresh: function(frm) {
-
-	// }
+	refresh: function(frm) {
+		if (frm.doc.import_file) {
+			frm.add_custom_button(__("Start Import"), () => {
+				// frm.call("start_import", {
+				// 	file_url: frm.doc.import_file,
+				// 	bank_account: frm.doc.bank_account,
+				// 	company: frm.doc.company,
+				// });
+			});
+		}
+	}
 });

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:DATEV OPOS Import on {creation}",
  "creation": "2024-04-23 09:23:34.743892",
  "default_view": "List",
  "doctype": "DocType",
@@ -20,10 +21,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-23 09:23:34.743892",
+ "modified": "2024-04-23 09:34:37.924267",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV OPOS Import",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -1,0 +1,45 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-04-23 09:23:34.743892",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "import_file"
+ ],
+ "fields": [
+  {
+   "fieldname": "import_file",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Import File",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-04-23 09:23:34.743892",
+ "modified_by": "Administrator",
+ "module": "German Accounting",
+ "name": "DATEV OPOS Import",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class DATEVOPOSImport(Document):
+	pass

--- a/german_accounting/german_accounting/doctype/datev_opos_import/test_datev_opos_import.py
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/test_datev_opos_import.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, phamos.eu and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDATEVOPOSImport(FrappeTestCase):
+	pass


### PR DESCRIPTION
"DATEV OPOS Import" doctype created and inserted all necessary fields. for now we just only have file attachment field but we might add more fields in the future. also added a "start import" custom button.

![Screenshot from 2024-04-23 10-42-25](https://github.com/phamos-eu/German-Accounting/assets/71070205/4c45b18b-b87b-4522-a243-1f01c9f5dfbf)
![Screenshot from 2024-04-23 10-42-00](https://github.com/phamos-eu/German-Accounting/assets/71070205/4f0bb62c-4da2-4f9a-a630-5f286cfd4ae6)
