### PR TITLE
feat: add payment entry record for sales invoice

### DIFF
--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -8,6 +8,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "month",
   "import_file"
  ],
  "fields": [
@@ -17,11 +18,16 @@
    "in_list_view": 1,
    "label": "Import File",
    "reqd": 1
+  },
+  {
+   "fieldname": "month",
+   "fieldtype": "Date",
+   "label": "Month"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-23 09:34:37.924267",
+ "modified": "2024-05-10 15:53:15.348007",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV OPOS Import",

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.utils.file_manager import get_file_path
+from frappe.utils import today
 from frappe.model.document import Document
 import os
 import csv
@@ -86,5 +87,9 @@ class DATEVOPOSImport(Document):
 			}, fields=["name"])
 
 		for invoice in invoices:
-	
-			frappe.db.set_value("Sales Invoice", invoice.name, "status", "Paid")
+			payment_entry = frappe.call("erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry", 'Sales Invoice', invoice.name)
+			payment_entry.reference_date = today()
+			payment_entry.reference_no = 'DATEV OPOS import '+ today()
+
+			payment_entry.insert()
+			payment_entry.submit()


### PR DESCRIPTION
When importing the csv file throught DATEV OPOS Import doctype, first it will create a payment entry record then that payment entry record will be submitted through programmatically, which then update the status of Sales Invoice to paid and also deduct the outstanding amount. The process will also create GL entry list which will follow the ERPNext standard processes.

![sales](https://github.com/phamos-eu/German-Accounting/assets/71070205/c6ff7a47-700d-4ccd-8613-d4dc1747ddef)
