### PR TITLE
fix: add color on banner

### DIFF
--- a/german_accounting/events/quotation_credit_limit_check.py
+++ b/german_accounting/events/quotation_credit_limit_check.py
@@ -63,10 +63,9 @@ def credit_limit(customer, company, ignore_outstanding_sales_order=False, extra_
 			)
 
 
-
+@frappe.whitelist()
 def get_credit_limit(customer, company):
 	credit_limit = None
-
 	if customer:
 		credit_limit = frappe.db.get_value(
 			"Customer Credit Limit",

--- a/german_accounting/public/js/banner/quotation_banner.js
+++ b/german_accounting/public/js/banner/quotation_banner.js
@@ -8,20 +8,29 @@ frappe.ui.form.on('Quotation', {
 		// if(!frm.is_new()) {
             if (frm.doc.party_name) {
                 const currencySymbol = await getDefaultCurrencySymbol();
-
+                const credit_limit =  (await getCreditLimit(frm.doc.party_name, frm.doc.company)).toFixed(2);
                 let customer = frm.doc.party_name
                 let open_invoice_amount = frm.doc.open_invoice_amount.toFixed(2)
                 let overdue_invoice_amount = frm.doc.overdue_invoice_amount.toFixed(2)
                 let non_invoiced_amount = frm.doc.non_invoiced_amount.toFixed(2)
                 let total = (parseFloat(open_invoice_amount)+parseFloat(non_invoiced_amount)).toFixed(2)
+
+                let creditLimitText = credit_limit !== '0.00' ? `and The Credit Limit is: <b>${currencySymbol} ${credit_limit}</b>` : `<br> <span style="color: #ff4d4d;">Credit Limit is not set for this customer</span>`;
+
+
+                let textColor = '#1366AE'; // Default text color
+                if ((parseFloat(total) > parseFloat(credit_limit)) && parseFloat(credit_limit) > 0) {
+                    textColor = '#ff4d4d'; // Red text color
+                }
                 frm.dashboard.clear_headline();
 
                 frm.dashboard.set_headline_alert(`
                     <div class="row">
                         <div class="col-xs-12">
-                            <span class="indicator whitespace-nowrap">
+                            <span class="indicator whitespace-nowrap" style="color: ${textColor};">
                                 <span class="hidden-xs">
-                                    <p>Customer <b>${customer}</b> has an Open Invoice Amount of: <b>${currencySymbol} ${open_invoice_amount}</b>, Overdue Invoice Amount of: <b>${currencySymbol} ${overdue_invoice_amount}</b> and Non-Invoiced Amount of: <b>${currencySymbol} ${non_invoiced_amount}</b><br> This is a Total of: <b>${currencySymbol} ${total}</b></p>
+                                    <p>Customer <b>${customer}</b> has an Open Invoice Amount of: <b>${currencySymbol} ${open_invoice_amount}</b>, Overdue Invoice Amount of: <b>${currencySymbol} ${overdue_invoice_amount}</b> and Non-Invoiced Amount of: <b>${currencySymbol} ${non_invoiced_amount}</b><br> This is a Total of: <b>${currencySymbol} ${total}</b> ${creditLimitText}
+                                    </p>
                                 </span>
                             </span>
                         </div>
@@ -52,4 +61,24 @@ async function getDefaultCurrencySymbol() {
         console.error("Error fetching default currency symbol:", error);
         return null;
     }
+}
+
+
+async function getCreditLimit(customer, company) {
+    return new Promise((resolve, reject) => {
+        frappe.call({
+            method: 'german_accounting.events.quotation_credit_limit_check.get_credit_limit',
+            args: {
+                customer: customer,
+                company: company
+            },
+            callback: function(r) {
+                if (r.message !== null && r.message !== undefined) {
+                    resolve(r.message);
+                } else {
+                    resolve(0);
+                }
+            }
+        });
+    });
 }


### PR DESCRIPTION
Credit Limit is set and Total > Credit Limit 

![image](https://github.com/phamos-eu/German-Accounting/assets/71070205/15788519-f6e0-48b2-b941-a37bba81d42b)

Credit Limit is set and Total <= Credit Limit

![image](https://github.com/phamos-eu/German-Accounting/assets/71070205/322278cd-106e-40f8-bbaf-fc184812cd29)

Credit Limit not set at all

![image](https://github.com/phamos-eu/German-Accounting/assets/71070205/8337475d-f229-47b4-a58f-e0f6f802cf85)

If Total > Credit Limit but if the Bypass Credit Limit Check at Quotation is checked on customer, the banner is red but the user can actually submit the document. as you see the quotation document is submitted.

![image](https://github.com/phamos-eu/German-Accounting/assets/71070205/df11f6c0-da6b-4852-98f4-7c76f5ef3a26)
