### PR TITLE
fix: include return status during import

### DIFF
--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
@@ -121,6 +121,11 @@ frappe.ui.form.on('DATEV Action Panel', {
 	show_report: function(frm){
 		frappe.open_in_new_tab = true;
 		frappe.set_route('query-report', 'DATEV Sales Invoice Export', {})
+	},
+
+	datev_opos_import: function(frm){
+		frappe.open_in_new_tab = true;
+		frappe.set_route('List', 'DATEV OPOS Import', {})
 	}
 
 });

--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.json
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.json
@@ -17,7 +17,11 @@
   "section_break_whs9x",
   "show_report_html",
   "column_break_p4usw",
-  "show_report"
+  "show_report",
+  "datev_imports_section",
+  "datev_import_html",
+  "column_break_hlyij",
+  "datev_opos_import"
  ],
  "fields": [
   {
@@ -28,7 +32,7 @@
   {
    "fieldname": "create_datev_html",
    "fieldtype": "HTML",
-   "options": "Mit dem Button <b>Create DATEV Export Logs</b> erstellen wir einen Export aller Ausgangsrechnungen (inkl. Stornos und Gutschriften) für den Import nach DATEV. Es werden alle Belege berücksichtigt die gebucht sind, zuvor nicht exportiert wurden und bei welchen die Stammdaten korrekt angelegt sind. Der Export bezieht sich auf einen Kalnedermonant kann aber mehrfach ausgelöst werden."
+   "options": "Mit dem Button <b>Create DATEV Export Logs</b> erstellen wir einen Export aller Ausgangsrechnungen (inkl. Stornos und Gutschriften) f\u00fcr den Import nach DATEV. Es werden alle Belege ber\u00fccksichtigt die gebucht sind, zuvor nicht exportiert wurden und bei welchen die Stammdaten korrekt angelegt sind. Der Export bezieht sich auf einen Kalnedermonant kann aber mehrfach ausgel\u00f6st werden."
   },
   {
    "fieldname": "column_break_ltkjn",
@@ -47,7 +51,7 @@
   {
    "fieldname": "show_export_logs_html",
    "fieldtype": "HTML",
-   "options": "Über diesen Button gelangen wir in die Listenansicht der bereits getätigten Exporte (DATEV Export Log). Dort können wir die *.csv Datei der Belege, eine Übersicht als *.pdf sowie die *.csv der Debitorenstammdaten einsehen und herunterladen."
+   "options": "\u00dcber diesen Button gelangen wir in die Listenansicht der bereits get\u00e4tigten Exporte (DATEV Export Log). Dort k\u00f6nnen wir die *.csv Datei der Belege, eine \u00dcbersicht als *.pdf sowie die *.csv der Debitorenstammdaten einsehen und herunterladen."
   },
   {
    "fieldname": "column_break_6sdmb",
@@ -66,7 +70,7 @@
   {
    "fieldname": "show_report_html",
    "fieldtype": "HTML",
-   "options": "Über diesen Button gelangen wir zu einer Ansicht in welcher wir die Daten wie sie in den Exporten abgebildet sind bzw. sein werden eingehen. Diese Ansichsten sind nicht belastbar. Die tatsächlich exportieren Daten finden sich in den DATEV Export Logs."
+   "options": "\u00dcber diesen Button gelangen wir zu einer Ansicht in welcher wir die Daten wie sie in den Exporten abgebildet sind bzw. sein werden eingehen. Diese Ansichsten sind nicht belastbar. Die tats\u00e4chlich exportieren Daten finden sich in den DATEV Export Logs."
   },
   {
    "fieldname": "show_report",
@@ -76,13 +80,32 @@
   {
    "fieldname": "column_break_p4usw",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "datev_imports_section",
+   "fieldtype": "Section Break",
+   "label": "DATEV IMPORTS"
+  },
+  {
+   "fieldname": "datev_import_html",
+   "fieldtype": "HTML",
+   "options": "Mit dem DATEV OPOS Import laden wir eine Datei hoch mit welcher wir den Zahlstatus des Ausgangsrechnungen \u00e4ndern. Die in der Datei enthaltenen Eintr\u00e4ge bilden die noch nicht bezahlten Rechnungen ab. Alle Ausgangsrechnungs IDs die also nicht in der Datei enthalten sind werden auf bezahlt gestellt. Ausnahmen gelten f\u00fcr den Status \"Abgebrochen (Cancelled), Entwurf (Draft), Gutschrift ausgel\u00f6st (Credit Note Issues) und Zur\u00fcck (Return)."
+  },
+  {
+   "fieldname": "column_break_hlyij",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "datev_opos_import",
+   "fieldtype": "Button",
+   "label": "DATEV OPOS Import"
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-04-02 03:10:24.445007",
+ "modified": "2024-06-11 07:57:16.522658",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV Action Panel",
@@ -97,5 +120,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -21,13 +21,14 @@
   },
   {
    "fieldname": "month",
-   "fieldtype": "Date",
-   "label": "Month"
+   "fieldtype": "Select",
+   "label": "Month",
+   "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-05-10 15:53:15.348007",
+ "modified": "2024-06-10 13:10:19.422695",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV OPOS Import",

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
@@ -82,7 +82,8 @@ class DATEVOPOSImport(Document):
 		csv_invoice_numbers = [row[1] for row in csv_data]
 		
 		invoices = frappe.get_all("Sales Invoice", filters={
-			"status": ["not in", ["Paid", "Cancelled", "Draft", "Credit Note Issued", "Return"]],
+			"status": ["not in", ["Paid", "Cancelled", "Draft", "Credit Note Issued"]],
+			"outstanding_amount": ["!=", 0],
 			"name": ["not in", csv_invoice_numbers]
 			}, fields=["name"])
         

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -4,8 +4,7 @@ from frappe.custom.doctype.property_setter.property_setter import make_property_
 
 def after_migrate():
 	create_custom_fields(get_custom_fields())
-
-
+	
 def before_uninstall():
 	delete_custom_fields(get_custom_fields())
 
@@ -162,11 +161,19 @@ def get_custom_fields():
 		},
 	]
 
-	custom_fields_si = [
+	custom_fields_si = [  
 		{
 			"label": "German Accounting",
 			"fieldname": "german_accounting",
 			"fieldtype": "Section Break",
+		},
+		{
+			"label": "Sales Invoice Type",
+			"fieldname": "custom_sales_invoice_type",
+			"fieldtype": "Select",
+			"options": "\nSales Invoice\nInvoice Cancellation\nCredit Note",   
+			"insert_after": "german_accounting",
+			"translatable": 1
 		},
 		{
 			"label": "Item Group",

--- a/german_accounting/translations/de.csv
+++ b/german_accounting/translations/de.csv
@@ -1,0 +1,3 @@
+Sales Invoice Type,Rechnungstyp
+Invoice Cancellation,Stornorechnung
+Credit Note,Bonusgutschrift


### PR DESCRIPTION
during import, if a return sales invoice document is not included on the import file, it will make a payment toward customer and make outstanding amount zero.

![return](https://github.com/phamos-eu/German-Accounting/assets/71070205/511c16b3-c4bd-41a5-964f-6e21f85abbe8)
