### PR TITLE
fix: datev opos import cleanup

### DIFF
--- a/german_accounting/events/sales_order_amount.py
+++ b/german_accounting/events/sales_order_amount.py
@@ -46,7 +46,6 @@ def update_overdue_invoice_amount(customer):
 
 
 def update_non_invoiced_amount(customer):
-
     total_non_invoiced_amount = 0.0
     total_billed_amount = 0.0
     net_non_invoice_amount = 0.0

--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.json
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.json
@@ -89,7 +89,7 @@
   {
    "fieldname": "datev_import_html",
    "fieldtype": "HTML",
-   "options": "Mit dem DATEV OPOS Import laden wir eine Datei hoch mit welcher wir den Zahlstatus des Ausgangsrechnungen \u00e4ndern. Die in der Datei enthaltenen Eintr\u00e4ge bilden die noch nicht bezahlten Rechnungen ab. Alle Ausgangsrechnungs IDs die also nicht in der Datei enthalten sind werden auf bezahlt gestellt. Ausnahmen gelten f\u00fcr den Status \"Abgebrochen (Cancelled), Entwurf (Draft), Gutschrift ausgel\u00f6st (Credit Note Issues) und Zur\u00fcck (Return)."
+   "options": "Mit dem DATEV OPOS Import laden wir eine Datei hoch mit welcher wir den Zahlstatus des Ausgangsrechnungen \u00e4ndern. Die in der Datei enthaltenen Eintr\u00e4ge bilden die noch nicht bezahlten Rechnungen ab. Alle Ausgangsrechnungs IDs die also nicht in der Datei enthalten sind werden auf bezahlt gestellt. Ausnahmen gelten f\u00fcr den Status \"Bezahlt (Paid), Abgebrochen (Cancelled), Entwurf (Draft) und Gutschrift ausgel\u00f6st (Credit Note Issues)."
   },
   {
    "fieldname": "column_break_hlyij",
@@ -105,7 +105,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-11 07:57:16.522658",
+ "modified": "2024-06-11 10:54:33.388127",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV Action Panel",

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
@@ -1,14 +1,65 @@
 // Copyright (c) 2024, phamos.eu and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('DATEV OPOS Import', {
-	refresh: function(frm) {
-		if (frm.doc.import_file) {
-			frm.add_custom_button(__("Start Import"), () => {
-				frm.call("start_import", {
-					file_url: frm.doc.import_file,
+frappe.ui.form.on("DATEV OPOS Import", {
+	setup(frm){
+		frappe.realtime.on('update_import_status', function(data) {
+			frm.reload_doc();
+		});
+	},
+	refresh(frm) {
+		$('.menu-btn-group').remove()
+		frm.page.hide_icon_group();
+
+
+		if (frm.doc.import_file &&
+			frm.doc.status !== 'Success' && 
+            frm.doc.status !== 'Partial Success' && 
+            frm.doc.status !== 'Error'
+		) {
+			frm.disable_save();
+			frm.page.set_primary_action("Start Import", () =>  {
+					frm.call("start_import", {
+						file_url: frm.doc.import_file,
+					});
 				});
-			});
 		}
+
+
+		if (frm.doc.status.includes("Success")) {
+			frm.disable_save();
+			frm.add_custom_button(__("Go to Sales Invoice List"), () =>
+				frappe.set_route("List", "Sales Invoice")
+			);
+		}
+
+		if (frm.doc.status.includes("Error")) {
+			frm.disable_save();
+			frm.page.set_primary_action("Retry", () =>  {
+					frm.call("start_import", {
+						file_url: frm.doc.import_file,
+					});
+				});
+		}
+
+		if(!frm.is_new()){
+			frm.trigger('set_headline')
+		}
+	},
+
+	set_headline(frm){
+		let message='';
+		let indicator='';
+	
+		if (frm.doc.status === 'Success') {
+			message = `Successfully imported.`;
+			indicator = 'blue';
+		} 
+		else if (frm.doc.status === 'Partial Success') {
+			message = `Partially imported. Fix the error for unimported rows.`;
+			indicator = 'orange';
+		}
+		
+		frm.dashboard.set_headline(message, indicator);
 	}
 });

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.js
@@ -42,6 +42,22 @@ frappe.ui.form.on("DATEV OPOS Import", {
 				});
 		}
 
+		if(frm.is_new()){
+			let currentDate = new Date();
+            let currentYear = currentDate.getFullYear();
+            let currentMonthIndex = currentDate.getMonth();
+
+			let monthNames = [
+                "January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"
+            ];
+
+			let currentMonth = monthNames[currentMonthIndex];
+
+            frm.set_value('year', currentYear);
+            frm.set_value('month', currentMonth);
+		}
+
 		if(!frm.is_new()){
 			frm.trigger('set_headline')
 		}

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -31,6 +31,7 @@
    "in_standard_filter": 1,
    "label": "Month",
    "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember",
+   "reqd": 1,
    "set_only_once": 1
   },
   {
@@ -60,12 +61,13 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Year",
+   "reqd": 1,
    "set_only_once": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-11 15:27:11.401419",
+ "modified": "2024-06-13 13:27:39.627243",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV OPOS Import",

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -9,7 +9,11 @@
  "engine": "InnoDB",
  "field_order": [
   "month",
-  "import_file"
+  "year",
+  "import_file",
+  "status",
+  "payload_count",
+  "imported_records"
  ],
  "fields": [
   {
@@ -17,18 +21,51 @@
    "fieldtype": "Attach",
    "in_list_view": 1,
    "label": "Import File",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "month",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Month",
-   "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember"
+   "options": "\nJanuary\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember",
+   "set_only_once": 1
+  },
+  {
+   "default": "Not Started",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Status",
+   "options": "Not Started\nSuccess\nPartial Success\nError",
+   "read_only": 1
+  },
+  {
+   "fieldname": "payload_count",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Payload Count"
+  },
+  {
+   "fieldname": "imported_records",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Imported Records"
+  },
+  {
+   "fieldname": "year",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Year",
+   "set_only_once": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-10 13:10:19.422695",
+ "modified": "2024-06-11 15:27:11.401419",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV OPOS Import",

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import_list.js
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import_list.js
@@ -1,0 +1,14 @@
+frappe.listview_settings["DATEV OPOS Import"] = {
+    get_indicator: function(doc) {
+        if (doc.status === "Not Started") {
+            return [__("Not Started"), "grey", "status,=,Not Started"];
+        } else if (doc.status === "Success") {
+            return [__("Success"), "green", "docstatus,=,Success"];
+        } else if (doc.status === "Partial Success") {
+            return [__("Partial Success"), "orange", "status,=,Partial Success"];
+        } else if (doc.status === "Error") {
+            return [__("Error"), "red", "status,=,Error"];
+        } 
+    },
+
+};

--- a/german_accounting/public/js/banner/sales_order_banner.js
+++ b/german_accounting/public/js/banner/sales_order_banner.js
@@ -8,7 +8,6 @@ frappe.ui.form.on('Sales Order', {
     },
 	refresh: (frm) => {
 		// if(!frm.is_new()) {
-            console.log(frm.doc.non_invoiced_amount, 'refresh')
 			frm.trigger('make_dashboard');
 		// }
 	},
@@ -21,7 +20,7 @@ frappe.ui.form.on('Sales Order', {
                 let open_invoice_amount = frm.doc.open_invoice_amount.toFixed(2)
                 let overdue_invoice_amount = frm.doc.overdue_invoice_amount.toFixed(2)
                 let non_invoiced_amount = frm.doc.non_invoiced_amount.toFixed(2)
-                console.log('heyheyhey', non_invoiced_amount)
+                
                 let total = frm.doc.totall.toFixed(2)
 
                 let creditLimitText = credit_limit !== '0.00' ? `and The Credit Limit is: <b>${currencySymbol} ${credit_limit}</b>` : `<br> <span style="color: #ff4d4d;">Credit Limit is not set for this customer</span>`;

--- a/german_accounting/public/js/banner/sales_order_banner.js
+++ b/german_accounting/public/js/banner/sales_order_banner.js
@@ -1,24 +1,14 @@
 
 frappe.ui.form.on('Sales Order', {
-    customer: (frm) => {
-        
-        const customer = frm.doc.customer
-        frappe.call({
-            method: "german_accounting.events.sales_order_amount.update_amounts",
-            args: {
-                customer: customer
-            },
-            callback: function (r) {
-               const val = r.message
-               frm.doc.open_invoice_amount = val[0]
-               frm.doc.overdue_invoice_amount = val[1]
-               frm.doc.non_invoiced_amount = val[2]
-               frm.doc.totall = val[3]
-            },
-        });
+    customer: async (frm) => {
+        await updateAmounts(frm)
+    },
+    onload: async (frm) => {
+        await updateAmounts(frm)
     },
 	refresh: (frm) => {
 		// if(!frm.is_new()) {
+            console.log(frm.doc.non_invoiced_amount, 'refresh')
 			frm.trigger('make_dashboard');
 		// }
 	},
@@ -31,6 +21,7 @@ frappe.ui.form.on('Sales Order', {
                 let open_invoice_amount = frm.doc.open_invoice_amount.toFixed(2)
                 let overdue_invoice_amount = frm.doc.overdue_invoice_amount.toFixed(2)
                 let non_invoiced_amount = frm.doc.non_invoiced_amount.toFixed(2)
+                console.log('heyheyhey', non_invoiced_amount)
                 let total = frm.doc.totall.toFixed(2)
 
                 let creditLimitText = credit_limit !== '0.00' ? `and The Credit Limit is: <b>${currencySymbol} ${credit_limit}</b>` : `<br> <span style="color: #ff4d4d;">Credit Limit is not set for this customer</span>`;
@@ -59,6 +50,25 @@ frappe.ui.form.on('Sales Order', {
 		// }
 	}
 })
+
+
+async function updateAmounts(frm) {
+
+    const customer = frm.doc.customer
+    frappe.call({
+        method: "german_accounting.events.sales_order_amount.update_amounts",
+        args: {
+            customer: customer
+        },
+        callback: function (r) {
+           const val = r.message
+           frm.doc.open_invoice_amount = val[0]
+           frm.doc.overdue_invoice_amount = val[1]
+           frm.doc.non_invoiced_amount = val[2]
+           frm.doc.totall = val[3]
+        },
+    });
+}
 
 
 async function getDefaultCurrencySymbol() {


### PR DESCRIPTION
[#23](https://git.phamos.eu/imat/imat-german-accounting/-/issues/23) changes

- Year added, also visible on list view and list filter
- Status added
- Success or Error message will be displayed after import
- Fields are set only once (They can't be edited after import)

![image](https://github.com/phamos-eu/German-Accounting/assets/71070205/6e2f839e-b1b7-4f70-a9c1-1f3ba25ea4bd)
![image](https://github.com/phamos-eu/German-Accounting/assets/71070205/e3d2a5ed-7a23-419a-90f2-319b113e57c2)

