### PR TITLE
feat: add year on create Datev Export Logs

### DIFF
--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
@@ -14,7 +14,7 @@ frappe.ui.form.on('DATEV Action Panel', {
 
 	export_datev_logs: function(frm){
 		let d = new frappe.ui.Dialog({
-			title: __("Select Month"),
+			title: __("Select Month and Year"),
 			fields: [
 				{
 					"fieldname": "month",
@@ -24,6 +24,13 @@ frappe.ui.form.on('DATEV Action Panel', {
 					"default": ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November",
 						"December"
 					][frappe.datetime.str_to_obj(frappe.datetime.get_today()).getMonth()],
+					"reqd": 1
+				},
+				{
+					"fieldname": "year",
+					"label": __("Year"),
+					"fieldtype": "Data",
+					"default": new Date().getFullYear(),
 					"reqd": 1
 				}
 			],
@@ -51,9 +58,11 @@ frappe.ui.form.on('DATEV Action Panel', {
 
 				datev_export_filters = {
 					'month': data.month,
+					'year': data.year,
 					'export_type': 'Sales Invoice CSV',
 					'unexported_sales_invoice': true
 				}
+				
 				let datev_export_csv = await get_datev_export_data(datev_export_filters);
 				if (datev_export_csv.message) {
 					datev_export_csv = datev_export_csv.message;

--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
@@ -14,8 +14,15 @@ frappe.ui.form.on('DATEV Action Panel', {
 
 	export_datev_logs: function(frm){
 		let d = new frappe.ui.Dialog({
-			title: __("Select Month and Year"),
+			title: __("Select Year and Month"),
 			fields: [
+				{
+					"fieldname": "year",
+					"label": __("Year"),
+					"fieldtype": "Data",
+					"default": new Date().getFullYear(),
+					"reqd": 1
+				},
 				{
 					"fieldname": "month",
 					"label": __("Month"),
@@ -24,13 +31,6 @@ frappe.ui.form.on('DATEV Action Panel', {
 					"default": ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November",
 						"December"
 					][frappe.datetime.str_to_obj(frappe.datetime.get_today()).getMonth()],
-					"reqd": 1
-				},
-				{
-					"fieldname": "year",
-					"label": __("Year"),
-					"fieldtype": "Data",
-					"default": new Date().getFullYear(),
 					"reqd": 1
 				}
 			],

--- a/german_accounting/german_accounting/report/datev_sales_invoice_export/datev_sales_invoice_export.py
+++ b/german_accounting/german_accounting/report/datev_sales_invoice_export/datev_sales_invoice_export.py
@@ -170,6 +170,9 @@ def get_conditions(filters):
 				"December"].index(filters.month) + 1
 		conditions += "AND month(si.posting_date) = %(month)s"
 
+	if filters.get("year"):
+		conditions += " AND year(si.posting_date) = %(year)s "
+
 	if filters.get("unexported_sales_invoice"):
 		conditions += " AND coalesce(si.custom_exported_on, '') = '' "
 


### PR DESCRIPTION
- The year has been added to the export log.
- The year is automatically set based on the current year value.

![image](https://github.com/phamos-eu/German-Accounting/assets/71070205/265ac749-d830-4c01-90bb-4dbb9331d2bb)
