### PR TITLE
feat: 39-adjust-sales-invoice-fields

### DIFF
--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -56,6 +56,7 @@ doctype_js = {
 	],
 	"Quotation": "public/js/banner/quotation_banner.js",
 	"Sales Order": "public/js/banner/sales_order_banner.js",
+	"Sales Invoice": "public/js/sales_invoice.js"
 }
 
 doc_events = {

--- a/german_accounting/public/js/sales_invoice.js
+++ b/german_accounting/public/js/sales_invoice.js
@@ -1,0 +1,53 @@
+frappe.ui.form.on('Sales Invoice', {
+
+    refresh: function(frm) {
+        frm.events.toggle_fields(frm);
+    },
+
+    custom_sales_invoice_type: function(frm) {
+        frm.events.toggle_fields(frm);
+    },
+
+    toggle_fields: function(frm) {
+        
+        if (frm.doc.custom_sales_invoice_type) {
+            // Details tab
+            frm.set_df_property('is_pos', 'hidden', true);
+            frm.set_df_property('is_return', 'hidden', true);
+            frm.set_df_property('is_debit_note', 'hidden', true);
+
+            // Payments tab
+            frm.set_df_property('advances_section', 'hidden', true);
+            frm.set_df_property('loyalty_points_redemption', 'hidden', true);
+
+            // Contact & Address tab
+            frm.set_df_property('dispatch_address_name', 'hidden', true);
+
+            // More Info
+            frm.set_df_property('is_opening', 'hidden', true);
+            frm.set_df_property('sales_team_section_break', 'hidden', true);
+            frm.set_df_property('subscription_section', 'hidden', true);
+            frm.set_df_property('more_information', 'hidden', true);
+                        
+        } else {
+            // Details tab
+            frm.set_df_property('is_pos', 'hidden', false);
+            frm.set_df_property('is_return', 'hidden', false);
+            frm.set_df_property('is_debit_note', 'hidden', false);
+
+            // Payments tab
+            frm.set_df_property('advances_section', 'hidden', false);
+            frm.set_df_property('loyalty_points_redemption', 'hidden', false);
+
+            // Contact & Address tab
+            frm.set_df_property('dispatch_address_name', 'hidden', false);
+
+            // More Info
+            frm.set_df_property('is_opening', 'hidden', false);
+            frm.set_df_property('sales_team_section_break', 'hidden', false);
+            frm.set_df_property('subscription_section', 'hidden', false);
+            frm.set_df_property('more_information', 'hidden', false);
+
+        }
+    }
+});


### PR DESCRIPTION
Task: [#78](https://git.phamos.eu/imat/imat-german-accounting/-/issues/39?work_item_iid=78)

Toggling the visibility of fields based on the selection of the sales invoice type is implemented. If the sales invoice type has a value, the specified fields will be hidden. Otherwise, if the sales invoice type does not have any value selected, the specified fields will be visible again.

![toggle_sales_invoice_fields](https://github.com/phamos-eu/German-Accounting/assets/71070205/807d28d0-3be4-4ef3-bf32-772abe8a5785)
