### PR TITLE
feat: 23-opos-Import-set-sales-invoices-back-to-unpaid

### DIFF
--- a/german_accounting/public/js/sales_invoice.js
+++ b/german_accounting/public/js/sales_invoice.js
@@ -1,5 +1,15 @@
 frappe.ui.form.on('Sales Invoice', {
-
+    onload: function(frm){
+        
+        if (frm.is_new() && frm.doc.items.some(item => item.sales_order)){
+            frm.doc.custom_sales_invoice_type = "Sales Invoice"
+            frm.events.toggle_fields(frm);
+        } 
+        else if (frm.is_new() && frm.doc.is_return){
+            frm.doc.custom_sales_invoice_type = "Invoice Cancellation"
+            frm.events.toggle_fields(frm);
+        }
+    },
     refresh: function(frm) {
         frm.events.toggle_fields(frm);
     },


### PR DESCRIPTION
Task: [#78](https://git.phamos.eu/imat/imat-german-accounting/-/work_items/78)

- When creating a Sales Invoice from a Sales Order the field "Sales Invoice Type"  automatically pre-selected with "Sales Invoice" in the new Sales Invoice Form.

- When creating a Return (Credit Note) from a Sales Invoice the field "Sales Invoice Type" automatically pre-selected with "Invoice Cancellation" in the new Return Form.

![automatic_set](https://github.com/phamos-eu/German-Accounting/assets/71070205/801929dd-0ae7-415e-9dc7-1fea2b8282f6)
