### PR TITLE
feat: 39-modify-adjust-sales-invoice-fields

### DIFF
--- a/german_accounting/public/js/sales_invoice.js
+++ b/german_accounting/public/js/sales_invoice.js
@@ -21,41 +21,93 @@ frappe.ui.form.on('Sales Invoice', {
         
         if (frm.doc.custom_sales_invoice_type) {
             // Details tab
-            frm.set_df_property('is_pos', 'hidden', true);
-            frm.set_df_property('is_return', 'hidden', true);
-            frm.set_df_property('is_debit_note', 'hidden', true);
+            frm.set_df_property('is_pos', 'read_only', true);
+            frm.set_df_property('is_return', 'read_only', true);
+            frm.set_df_property('is_debit_note', 'read_only', true);
 
             // Payments tab
-            frm.set_df_property('advances_section', 'hidden', true);
-            frm.set_df_property('loyalty_points_redemption', 'hidden', true);
+
+                // advance section
+            frm.set_df_property('allocate_advances_automatically', 'read_only', true);
+            frm.set_df_property('only_include_allocated_payments', 'read_only', true);
+            frm.set_df_property('get_advances', 'read_only', true);
+            frm.set_df_property('advances', 'read_only', true);
+            
+                // loyalty section
+            frm.set_df_property('redeem_loyalty_points', 'read_only', true);
+            frm.set_df_property('loyalty_points', 'read_only', true);
+            frm.set_df_property('loyalty_program', 'read_only', true);
+            
 
             // Contact & Address tab
-            frm.set_df_property('dispatch_address_name', 'hidden', true);
+            frm.set_df_property('dispatch_address_name', 'read_only', true);
 
-            // More Info
-            frm.set_df_property('is_opening', 'hidden', true);
-            frm.set_df_property('sales_team_section_break', 'hidden', true);
-            frm.set_df_property('subscription_section', 'hidden', true);
-            frm.set_df_property('more_information', 'hidden', true);
+            // More Info tab
+            frm.set_df_property('is_opening', 'read_only', true);
+
+                // commission section
+            frm.set_df_property('sales_partner', 'read_only', true);
+            frm.set_df_property('amount_eligible_for_commission', 'read_only', true);
+            frm.set_df_property('commission_rate', 'read_only', true);
+            frm.set_df_property('total_commission', 'read_only', true);
+
+                // subscription section
+            frm.set_df_property('from_date', 'read_only', true);
+            frm.set_df_property('to_date', 'read_only', true);
+
+                // additional info section
+            frm.set_df_property('status', 'read_only', true);
+            frm.set_df_property('campaign', 'read_only', true);
+            frm.set_df_property('source', 'read_only', true);
+            frm.set_df_property('customer_group', 'read_only', true);
+            frm.set_df_property('is_internal_customer', 'read_only', true);
+            frm.set_df_property('is_discounted', 'read_only', true);
+            frm.set_df_property('remarks', 'read_only', true);
+
+            
                         
         } else {
             // Details tab
-            frm.set_df_property('is_pos', 'hidden', false);
-            frm.set_df_property('is_return', 'hidden', false);
-            frm.set_df_property('is_debit_note', 'hidden', false);
+            frm.set_df_property('is_pos', 'read_only', false);
+            frm.set_df_property('is_return', 'read_only', false);
+            frm.set_df_property('is_debit_note', 'read_only', false);
 
             // Payments tab
-            frm.set_df_property('advances_section', 'hidden', false);
-            frm.set_df_property('loyalty_points_redemption', 'hidden', false);
+                // advance section
+            frm.set_df_property('allocate_advances_automatically', 'read_only', false);
+            frm.set_df_property('only_include_allocated_payments', 'read_only', false);
+            frm.set_df_property('get_advances', 'read_only', false);
+            frm.set_df_property('advances', 'read_only', false);
+
+                // loyalty section
+            frm.set_df_property('redeem_loyalty_points', 'read_only', false);
+            frm.set_df_property('loyalty_points', 'read_only', false);
+            frm.set_df_property('loyalty_program', 'read_only', false);
 
             // Contact & Address tab
-            frm.set_df_property('dispatch_address_name', 'hidden', false);
+            frm.set_df_property('dispatch_address_name', 'read_only', false);
 
-            // More Info
-            frm.set_df_property('is_opening', 'hidden', false);
-            frm.set_df_property('sales_team_section_break', 'hidden', false);
-            frm.set_df_property('subscription_section', 'hidden', false);
-            frm.set_df_property('more_information', 'hidden', false);
+            // More Info tab
+            frm.set_df_property('is_opening', 'read_only', false);
+
+                // commission section
+            frm.set_df_property('sales_partner', 'read_only', false);
+            frm.set_df_property('amount_eligible_for_commission', 'read_only', false);
+            frm.set_df_property('commission_rate', 'read_only', false);
+            frm.set_df_property('total_commission', 'read_only', false);
+
+                // subscription section
+            frm.set_df_property('from_date', 'read_only', false);
+            frm.set_df_property('to_date', 'read_only', false);
+
+                // additional info section
+            frm.set_df_property('status', 'read_only', false);
+            frm.set_df_property('campaign', 'read_only', false);
+            frm.set_df_property('source', 'read_only', false);
+            frm.set_df_property('customer_group', 'read_only', false);
+            frm.set_df_property('is_internal_customer', 'read_only', false);
+            frm.set_df_property('is_discounted', 'read_only', false);
+            frm.set_df_property('remarks', 'read_only', false);
 
         }
     }

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -172,7 +172,9 @@ def get_custom_fields():
 			"fieldname": "custom_sales_invoice_type",
 			"fieldtype": "Select",
 			"options": "\nSales Invoice\nInvoice Cancellation\nCredit Note",   
+			"default": "Sales Invoice",
 			"insert_after": "german_accounting",
+			"allow_on_submit": 0,
 			"translatable": 1
 		},
 		{


### PR DESCRIPTION
- Make the default value of sales invoice type to be a "Sales Invoice".
- Make all the required fields to be read_only rather than hidden during selection of sales invoice type.
- Removed "Allow on Submit" attribute of sales invoice type.