### PR TITLE
feature/87-multi-company-adaptions

### DIFF
--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -10,6 +10,7 @@
  "field_order": [
   "month",
   "year",
+  "company",
   "import_file",
   "status",
   "payload_count",
@@ -63,11 +64,17 @@
    "label": "Year",
    "reqd": 1,
    "set_only_once": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-13 13:27:39.627243",
+ "modified": "2024-08-07 09:53:23.081553",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV OPOS Import",

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.json
@@ -69,12 +69,13 @@
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
-   "options": "Company"
+   "options": "Company",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-07 09:53:23.081553",
+ "modified": "2024-08-07 14:16:03.246191",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV OPOS Import",

--- a/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
+++ b/german_accounting/german_accounting/doctype/datev_opos_import/datev_opos_import.py
@@ -95,12 +95,14 @@ class DATEVOPOSImport(Document):
 		invoices = frappe.get_all("Sales Invoice", filters={
 			"status": ["not in", ["Paid", "Cancelled", "Draft", "Credit Note Issued"]],
 			"outstanding_amount": ["!=", 0],
-			"name": ["not in", csv_invoice_numbers]
+			"name": ["not in", csv_invoice_numbers],
+			"company": self.company
 			}, fields=["name"])
         
 		for index,invoice in enumerate(invoices):
 			try:
 				payment_entry = frappe.call("erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry", 'Sales Invoice', invoice.name)
+				payment_entry.company = self.company
 				payment_entry.reference_date = today()
 				payment_entry.reference_no = 'DATEV OPOS import '+ today()
 
@@ -115,7 +117,8 @@ class DATEVOPOSImport(Document):
 		# Get all sales invoice which are paid or partly paid and ID of the current import list
 		paid_invoices = frappe.get_all("Sales Invoice", filters={
 			"status": ["in", ["Paid", "Partly Paid"]],
-			"name": ["in", csv_invoice_numbers]
+			"name": ["in", csv_invoice_numbers],
+			"company": self.company
 			}, fields=["name"])
 		
 		for index,invoice in enumerate(paid_invoices):


### PR DESCRIPTION
Task: [#87](https://git.phamos.eu/imat/imat-german-accounting/-/issues/87?work_item_iid=90)

- Added a company field on the DATEV OPOS Import doctype.
- When updating the status of Sales Invoices record it will only consider records of the company selected on the current import.
- Payment Entries will also have the same company record as the selected one on the import doctype

![datev_opos_import_multi_company](https://github.com/user-attachments/assets/054f8f02-07a5-472d-a0f4-3f09c1932848)
