### PR TITLE
feature: 87-multi-company-adaptions

### DIFF
--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
@@ -2,8 +2,40 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('DATEV Action Panel', {
-	// Copyright (c) 2024, phamos.eu and contributors
-	// For license information, please see license.txt
+	refresh: function(frm){
+		const company = frappe.defaults.get_default("company")
+		frappe.call({
+            method: "german_accounting.german_accounting.doctype.datev_action_panel.datev_action_panel.get_company_details",
+            args: {
+                company_name: company
+            },
+            callback: function(r) {
+				const company_details = r.message;
+				$('.title-area .title-text').text('DATEV Action Panel for ' + company_details.company_name);
+				if (company_details.country === 'Germany') {
+					frm.set_df_property('non_german_company_html', 'hidden', true);
+
+				} else {
+					frm.set_df_property('datev_exports_section', 'hidden', true);
+					frm.set_df_property('show_report_html', 'hidden', true);
+					frm.set_df_property('column_break_p4usw', 'hidden', true);
+					frm.set_df_property('show_report', 'hidden', true);
+					frm.set_df_property('section_break_dteax', 'hidden', true);
+					frm.set_df_property('create_datev_html', 'hidden', true);
+					frm.set_df_property('column_break_ltkjn', 'hidden', true);
+					frm.set_df_property('create_datev_export_logs', 'hidden', true);
+					frm.set_df_property('section_break_61fja', 'hidden', true);
+					frm.set_df_property('show_export_logs_html', 'hidden', true);
+					frm.set_df_property('column_break_6sdmb', 'hidden', true);
+					frm.set_df_property('show_export_logs', 'hidden', true);
+					frm.set_df_property('datev_imports_section', 'hidden', true);
+					frm.set_df_property('datev_import_html', 'hidden', true);
+					frm.set_df_property('column_break_hlyij', 'hidden', true);
+					frm.set_df_property('datev_opos_import', 'hidden', true);					
+				}
+			}
+		})
+	},
 	onload: function (frm) {
 		$('.page-actions').hide();
 	},

--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.js
@@ -33,12 +33,6 @@ frappe.ui.form.on('DATEV Action Panel', {
 					][frappe.datetime.str_to_obj(frappe.datetime.get_today()).getMonth()],
 					"reqd": 1
 				},
-				{
-					"fieldname": "company",
-					"label": __("Company"),
-					"fieldtype": "Link",
-					"options": "Company"
-				}
 			],
 			primary_action: async function () {
 				let data = d.get_values();
@@ -47,7 +41,7 @@ frappe.ui.form.on('DATEV Action Panel', {
 					args: {
 						"month": data.month,
 						"year": data.year,
-						"company": data.company,
+						"company": frappe.defaults.get_default("company"),
 					},
 					callback: function (r) {
 

--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.json
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.json
@@ -21,7 +21,9 @@
   "datev_imports_section",
   "datev_import_html",
   "column_break_hlyij",
-  "datev_opos_import"
+  "datev_opos_import",
+  "non_german_company_section",
+  "non_german_company_html"
  ],
  "fields": [
   {
@@ -98,13 +100,23 @@
   {
    "fieldname": "section_break_dteax",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "non_german_company_section",
+   "fieldtype": "Section Break",
+   "label": "Non-German Company"
+  },
+  {
+   "fieldname": "non_german_company_html",
+   "fieldtype": "HTML",
+   "options": "Your company is not located in Germany."
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-18 09:44:38.829473",
+ "modified": "2024-08-08 12:17:21.529724",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "DATEV Action Panel",

--- a/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.py
+++ b/german_accounting/german_accounting/doctype/datev_action_panel/datev_action_panel.py
@@ -166,3 +166,11 @@ def create_log(month, company=None, sales_invoices=[]):
 		frappe.db.set_value("Sales Invoice", si, "custom_exported_on", exported_on)
 		
 	return log_doc
+
+@frappe.whitelist()
+def get_company_details(company_name):
+    company = frappe.get_doc("Company", company_name)
+    return {
+        "company_name": company.name,
+        "country": company.country
+    }


### PR DESCRIPTION
Task: [#89](https://git.phamos.eu/imat/imat-german-accounting/-/issues/87?work_item_iid=89)

- Removed the `Company` filter from the popup and used the current user default company on the code.

![image](https://github.com/user-attachments/assets/feb2419b-a6e0-4845-aa28-ce89f2dbfc5a)

Task: [#88](https://git.phamos.eu/imat/imat-german-accounting/-/issues/87?work_item_iid=88)

- If the "Default Company" of the user's current session **is located** in Germany, the content of the action panel is fully shown and  the heading above the actions will be "DATEV Action Panel for {{"Default Company" of the user's current session}}"

- If the "Default Company" of the user's current session **is not located** in Germany, the content of the action panel will be changed to "Your company is not located in Germany." and the heading above the actions will be "DATEV Action Panel for {{"Default Company" of the user's current session}}"

![datev_action_panel_multi_company](https://github.com/user-attachments/assets/19bda139-e5ec-4272-9349-576465eabb37)
