### PR TITLE
fix: 41-remove-bypass-credit-limit-check-quotation

### DIFF
--- a/german_accounting/public/js/banner/quotation_banner.js
+++ b/german_accounting/public/js/banner/quotation_banner.js
@@ -11,10 +11,10 @@ frappe.ui.form.on('Quotation', {
     },
     before_submit: async (frm) => {
         const { party_name: customer, company, doctype, name: docname } = frm.doc;
-        const { amounts, credit_limit, check_bypass } = await getDataForHeadlineText(customer, company, doctype);
+        const { amounts, credit_limit } = await getDataForHeadlineText(customer, company, doctype);
         const total = parseFloat(amounts.total).toFixed(2);
 
-        if (parseFloat(total) > parseFloat(credit_limit) && parseFloat(credit_limit) > 0 && !check_bypass) {
+        if (parseFloat(total) > parseFloat(credit_limit) && parseFloat(credit_limit) > 0) {
             frappe.validated = false;
             checkCreditLimit(frm, customer, company, doctype, docname, total);
         }

--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -190,14 +190,6 @@ def get_custom_fields():
 		},
 	]
 
-	custom_fields_customer_credit_limit = [
-		{
-			"label": "Bypass Credit Limit Check at Quotation",
-			"fieldname": "bypass_credit_limit_check_quotation",
-			"fieldtype": "Check",
-			"insert_after": "bypass_credit_limit_check"
-		}
-	]
 
 	return {
 		"Quotation": custom_fields_quotation,
@@ -207,5 +199,4 @@ def get_custom_fields():
 		"Country": custom_fields_country,
 		"Customer": custom_fields_customer,
 		"Party Account": custom_fields_party_account,
-		"Customer Credit Limit": custom_fields_customer_credit_limit
 	}


### PR DESCRIPTION
- Removed `Bypass Credit Limit Check at Quotation` field from `Customer`  credit limit child table.
- Removed all of it's dependencies from the code.

![image](https://github.com/user-attachments/assets/a597b46b-6f98-4fc6-aab2-223aa404cdab)


