### PR TITLE
fix: 28-remove-monkey-patching

### DIFF
--- a/german_accounting/__init__.py
+++ b/german_accounting/__init__.py
@@ -1,4 +1,4 @@
 
 __version__ = '0.0.1'
 
-from . import overrides
+# from . import overrides

--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -138,10 +138,10 @@ before_uninstall = "german_accounting.setup.install.before_uninstall"
 # ---------------
 # Override standard doctype classes
 
-# override_doctype_class = {
-# 	# "Sales Order": "german_accounting.overrides.sales_order.custom_sales_order.CustomSalesOrder",
-# 	# "Sales Invoice": "german_accounting.overrides.sales_invoice.custom_sales_invoice.CustomSalesInvoice"
-# }
+override_doctype_class = {
+	"Sales Order": "german_accounting.overrides.sales_order.custom_sales_order.CustomSalesOrder",
+	"Sales Invoice": "german_accounting.overrides.sales_invoice.custom_sales_invoice.CustomSalesInvoice"
+}
 
 # Document Events
 # ---------------

--- a/german_accounting/overrides/sales_invoice/custom_sales_invoice.py
+++ b/german_accounting/overrides/sales_invoice/custom_sales_invoice.py
@@ -1,0 +1,73 @@
+import frappe
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import SalesInvoice as OriginalSalesInvoice
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import update_linked_doc
+from frappe.utils import cint
+from erpnext.setup.doctype.company.company import update_company_current_month_sales
+
+class CustomSalesInvoice(OriginalSalesInvoice):
+	def on_submit(self):
+		self.validate_pos_paid_amount()
+
+		if not self.auto_repeat:
+			frappe.get_doc("Authorization Control").validate_approving_authority(
+				self.doctype, self.company, self.base_grand_total, self
+			)
+
+		self.check_prev_docstatus()
+
+		if self.is_return and not self.update_billed_amount_in_sales_order:
+			# NOTE status updating bypassed for is_return
+			self.status_updater = []
+
+		self.update_status_updater_args()
+		self.update_prevdoc_status()
+
+		self.update_billing_status_in_dn()
+		self.clear_unallocated_mode_of_payments()
+
+		# Updating stock ledger should always be called after updating prevdoc status,
+		# because updating reserved qty in bin depends upon updated delivered qty in SO
+		if self.update_stock == 1:
+			self.update_stock_ledger()
+		if self.is_return and self.update_stock:
+			update_serial_nos_after_submit(self, "items")
+
+		# this sequence because outstanding may get -ve
+		self.make_gl_entries()
+
+		if self.update_stock == 1:
+			self.repost_future_sle_and_gle()
+
+		if not self.is_return:
+			self.update_billing_status_for_zero_amount_refdoc("Delivery Note")
+			self.update_billing_status_for_zero_amount_refdoc("Sales Order")
+			# Removed self.check_credit_limit()
+
+		self.update_serial_no()
+
+		if not cint(self.is_pos) == 1 and not self.is_return:
+			self.update_against_document_in_jv()
+
+		self.update_time_sheet(self.name)
+
+		if frappe.db.get_single_value("Selling Settings", "sales_update_frequency") == "Each Transaction":
+			update_company_current_month_sales(self.company)
+			self.update_project()
+		update_linked_doc(self.doctype, self.name, self.inter_company_invoice_reference)
+
+		# create the loyalty point ledger entry if the customer is enrolled in any loyalty program
+		if (
+			not self.is_return
+			and not self.is_consolidated
+			and self.loyalty_program
+			and not self.dont_create_loyalty_points
+		):
+			self.make_loyalty_point_entry()
+		elif self.is_return and self.return_against and not self.is_consolidated and self.loyalty_program:
+			against_si_doc = frappe.get_doc("Sales Invoice", self.return_against)
+			against_si_doc.delete_loyalty_point_entry()
+			against_si_doc.make_loyalty_point_entry()
+		if self.redeem_loyalty_points and not self.is_consolidated and self.loyalty_points:
+			self.apply_loyalty_points()
+
+		self.process_common_party_accounting()

--- a/german_accounting/overrides/sales_order/custom_sales_order.py
+++ b/german_accounting/overrides/sales_order/custom_sales_order.py
@@ -1,0 +1,25 @@
+import frappe
+from erpnext.selling.doctype.sales_order.sales_order import SalesOrder as OriginalSalesOrder
+from frappe.model.document import Document
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
+	update_linked_doc,
+)
+
+class CustomSalesOrder(OriginalSalesOrder):
+    def on_submit(self):
+        # Override the method and remove self.check_credit_limit()
+        self.update_reserved_qty()
+
+        frappe.get_doc("Authorization Control").validate_approving_authority(
+            self.doctype, self.company, self.base_grand_total, self
+        )
+        self.update_project()
+        self.update_prevdoc_status("submit")
+
+        self.update_blanket_order()
+
+        update_linked_doc(self.doctype, self.name, self.inter_company_order_reference)
+        if self.coupon_code:
+            from erpnext.accounts.doctype.pricing_rule.utils import update_coupon_code_count
+
+            update_coupon_code_count(self.coupon_code, "used")


### PR DESCRIPTION
- Removed the monkey patching approach to override credit limit checks on sales orders and sales invoices
- Used the `override_doctype_class` hook to override the credit limit check.