### PR TITLE
disabling hooks.py overrides_doctype_class and extended sales order

### DIFF
--- a/german_accounting/hooks.py
+++ b/german_accounting/hooks.py
@@ -136,8 +136,8 @@ before_uninstall = "german_accounting.setup.install.before_uninstall"
 # Override standard doctype classes
 
 override_doctype_class = {
-	"Sales Order": "german_accounting.overrides.sales_order.custom_sales_order.CustomSalesOrder",
-	"Sales Invoice": "german_accounting.overrides.sales_invoice.custom_sales_invoice.CustomSalesInvoice"
+	# "Sales Order": "german_accounting.overrides.sales_order.custom_sales_order.CustomSalesOrder",
+	# "Sales Invoice": "german_accounting.overrides.sales_invoice.custom_sales_invoice.CustomSalesInvoice"
 }
 
 # Document Events

--- a/german_accounting/overrides/sales_order/custom_sales_order.py
+++ b/german_accounting/overrides/sales_order/custom_sales_order.py
@@ -6,6 +6,10 @@ from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 )
 
 class CustomSalesOrder(OriginalSalesOrder):
+    def validate(self):
+        frappe.msgprint("Germany Accounting APP")
+        super().validate()
+
     def on_submit(self):
         # Override the method and remove self.check_credit_limit()
         self.update_reserved_qty()


### PR DESCRIPTION
disabling hooks.py overrides_doctype_class and extended sales order