### PR TITLE
feature/94-extend-payment-term

### DIFF
--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -180,6 +180,7 @@ def get_custom_fields():
 			"options": "Address"
 		}
 	]
+
 	custom_fields_party_account = [
 		{
 			"label": "Debtor/Creditor Number",
@@ -190,6 +191,14 @@ def get_custom_fields():
 		},
 	]
 
+	custom_fields_payment_term = [
+		{
+			"label": "Datev Export Number",
+			"fieldname": "datev_export_number",
+			"fieldtype": "Int",
+			"in_list_view": 1
+		}
+	]
 
 	return {
 		"Quotation": custom_fields_quotation,
@@ -199,4 +208,5 @@ def get_custom_fields():
 		"Country": custom_fields_country,
 		"Customer": custom_fields_customer,
 		"Party Account": custom_fields_party_account,
+		"Payment Term": custom_fields_payment_term
 	}


### PR DESCRIPTION
- Task: [#94](https://git.phamos.eu/imat/imat-german-accounting/-/issues/93?work_item_iid=94)
- Added `Datev Export Number` custom field to Doctype Payment Term.
- Displayed the field values in the List View of Doctype Payment.

![image](https://github.com/user-attachments/assets/154a4494-4169-41f3-b869-a8ad57736ba5)
