### PR TITLE
feature/91-german-accounting-settings-adjustment

### DIFF
--- a/german_accounting/events/credit_limit_check.py
+++ b/german_accounting/events/credit_limit_check.py
@@ -126,7 +126,7 @@ def check_credit_limit(docname, customer, company, total, doctype, method=None):
 
   table = ""
   button_label = "Submit"
-  role = frappe.db.get_single_value("German Accounting Settings", "credit_controller_role")
+  role = frappe.db.get_single_value("German Accounting Settings", "credit_limit_controller_role")
    
   if doctype != "Quotation" and not user_has_german_accounting_order_approval_role(role):
     button_label = "Request Approval"

--- a/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
+++ b/german_accounting/german_accounting/doctype/german_accounting_settings/german_accounting_settings.json
@@ -13,8 +13,8 @@
   "good_or_service_selection",
   "datev_export_section",
   "include_header_in_csv",
-  "credit_controller_section",
-  "credit_controller_role"
+  "credit_limit_controller_section",
+  "credit_limit_controller_role"
  ],
  "fields": [
   {
@@ -65,21 +65,21 @@
    "options": "Error Only\nError or Info"
   },
   {
-   "fieldname": "credit_controller_section",
+   "fieldname": "credit_limit_controller_section",
    "fieldtype": "Section Break",
-   "label": "Credit Controller"
+   "label": "Credit Limit Controller"
   },
   {
-   "fieldname": "credit_controller_role",
+   "fieldname": "credit_limit_controller_role",
    "fieldtype": "Link",
-   "label": "Credit Controller Role",
+   "label": "Credit Limit Controller Role",
    "options": "Role"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-08-06 13:58:10.615318",
+ "modified": "2024-08-19 14:20:33.356879",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "German Accounting Settings",


### PR DESCRIPTION
- Task: [#95](https://git.phamos.eu/imat/imat-german-accounting/-/issues/91?work_item_iid=95)
- Renamed `Credit Controller` and `Credit Controller Role` to `Credit Limit Controller` and `Credit Limit Controller Role` respectively.
- Modified all dependencies on the code related to this fields.

![german_accounting_settings](https://github.com/user-attachments/assets/75540a35-3ef7-496d-abf1-607a17fde832)
