### PR TITLE
fix: 91-datev-action-panel-page-accessible-in-global-search

### DIFF
--- a/german_accounting/german_accounting/page/datev_action_panel/datev_action_panel.json
+++ b/german_accounting/german_accounting/page/datev_action_panel/datev_action_panel.json
@@ -4,7 +4,7 @@
  "docstatus": 0,
  "doctype": "Page",
  "idx": 0,
- "modified": "2024-08-12 10:11:25.351784",
+ "modified": "2024-08-20 13:37:31.058453",
  "modified_by": "Administrator",
  "module": "German Accounting",
  "name": "datev-action-panel",
@@ -18,5 +18,6 @@
  "script": null,
  "standard": "Yes",
  "style": null,
- "system_page": 0
+ "system_page": 0,
+ "title": "DATEV Action Panel"
 }


### PR DESCRIPTION
Task: [#91](https://git.phamos.eu/imat/imat-german-accounting/-/issues/91?work_item_iid=97)
- Made Datev Action Panel page is accessible in global search by adding a title on the page

![datev-action-panel-page](https://github.com/user-attachments/assets/74ef02c2-d04c-4e5a-b3f2-5d451c1946e0)

