### PR TITLE
feature: 94-extend-payment-terms-template

### DIFF
--- a/german_accounting/setup/install.py
+++ b/german_accounting/setup/install.py
@@ -191,13 +191,25 @@ def get_custom_fields():
 		},
 	]
 
-	custom_fields_payment_term = [
+	custom_fields_payment_terms_template = [  
 		{
-			"label": "Datev Export Number",
-			"fieldname": "datev_export_number",
-			"fieldtype": "Int",
-			"in_list_view": 1
-		}
+			"label": "German Accounting",
+			"fieldname": "custom_german_accounting_section",
+			"fieldtype": "Section Break",
+			"insert_after": None,
+		},
+		{
+			"label": "DATEV Export Number",
+			"fieldname": "custom_datev_export_number",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"insert_after": "custom_german_accounting_section",
+		},
+		{
+			"fieldtype": "Section Break",
+			"fieldname": "custom_section_break_1ga",
+			"insert_after": "custom_datev_export_number",
+		},
 	]
 
 	return {
@@ -208,5 +220,5 @@ def get_custom_fields():
 		"Country": custom_fields_country,
 		"Customer": custom_fields_customer,
 		"Party Account": custom_fields_party_account,
-		"Payment Term": custom_fields_payment_term
+		"Payment Terms Template": custom_fields_payment_terms_template
 	}

--- a/german_accounting/translations/de.csv
+++ b/german_accounting/translations/de.csv
@@ -29,3 +29,5 @@ DATEV OPOS Import,DATEV OPOS Import
 Debitor No. Datev,Debitoren-Nr. Datev
 Invoice No.,Rechnungsnummer
 Non-German Company,Nicht-deutsches Unternehmen
+DATEV Export Number,DATEV-Exportnummer
+German Accounting,Deutsche Buchhaltung


### PR DESCRIPTION
- Task: [#94](https://git.phamos.eu/imat/imat-german-accounting/-/issues/93?work_item_iid=94)
- Removed the `DATEV Export Number` custom field from Payment Term doctype.
- Added the `DATEV Export Number` custom field on Payment Term Template doctype and also display it on list view.
- Added translations for the created custom fields.

![payment-term-template](https://github.com/user-attachments/assets/ed7bcc02-f832-481e-97a9-65734f184af2)
List View
![image](https://github.com/user-attachments/assets/22b29676-9701-43a6-9a2c-cfa287628855)

