### PR TITLE
feature: 122-sales-invoice-submit-validation

### DIFF
--- a/german_accounting/public/js/sales_invoice.js
+++ b/german_accounting/public/js/sales_invoice.js
@@ -9,6 +9,13 @@ frappe.ui.form.on('Sales Invoice', {
             frm.events.toggle_fields(frm);
         }   
     },
+
+    before_submit: function(frm){
+        if (frm.doc.grand_total === 0) {
+            frappe.throw(__("The grand total can't be zero."));
+        }
+    },
+
     refresh: function(frm) {
         frm.events.toggle_fields(frm);
     },
@@ -18,7 +25,6 @@ frappe.ui.form.on('Sales Invoice', {
     },
 
     toggle_fields: function(frm) {
-        
         
             if (frm.doc.sales_invoice_type === "Sales Invoice"){
                 // Details tab
@@ -52,7 +58,6 @@ frappe.ui.form.on('Sales Invoice', {
 
                 frm.set_value('update_outstanding_for_self', 0);
             }
-
             
             // Payments tab
             frm.set_df_property('advances_section', 'hidden', true);
@@ -65,7 +70,6 @@ frappe.ui.form.on('Sales Invoice', {
             frm.set_df_property('is_opening', 'hidden', true);
             frm.set_df_property('sales_team_section_break', 'hidden', true);
             frm.set_df_property('subscription_section', 'hidden', true);
-            frm.set_df_property('more_information', 'hidden', true);                        
-              
+            frm.set_df_property('more_information', 'hidden', true);                             
     }
 });

--- a/german_accounting/translations/de.csv
+++ b/german_accounting/translations/de.csv
@@ -117,3 +117,4 @@ DATEV Export Mapping Sales Invoice Field
 Default Company country {0} must be Germany,Das Standard-Firmenland {0} muss Deutschland sein
 Default Company not set,Standardfirma nicht festgelegt
 Please set default company for current user,Bitte legen Sie das Standardunternehmen für den aktuellen Benutzer fest
+The grand total can't be zero.,Der Rechnungsbetrag darf nicht Null sein.


### PR DESCRIPTION
Task: [#123](https://git.phamos.eu/imat/imat-german-accounting/-/issues/122?work_item_iid=123)

- Prevents submission of Sales Invoice if the grand total is zero, displaying the message `The grand total can't be zero`.

![validation](https://github.com/user-attachments/assets/919827c1-500d-4fa1-9e62-e0cc3c5cf6ca)
